### PR TITLE
Fix repository url typo

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -75,6 +75,6 @@ launch_buttons:
   colab_url                 : "" # The URL of Google Colab (https://colab.research.google.com)
 
 repository:
-  url                       : https://github.com/neuromatch/climate-ourse-content  # The URL to your book's repository
+  url                       : https://github.com/neuromatch/climate-course-content  # The URL to your book's repository
   path_to_book              : book  # A path to your book's folder, relative to the repository root.
   branch                    : main  # Which branch of the repository should be used when creating links


### PR DESCRIPTION
Hey!

Looks like there was a typo in your Jupyter Book `_config.yml`, which meant that the launcher into "https://climatematch.2i2c.cloud" wasn't working properly.