### PR TITLE
Update materials.yml tutorials number from 6 to 7 to include w2d4t7

### DIFF
--- a/tutorials/materials.yml
+++ b/tutorials/materials.yml
@@ -47,4 +47,4 @@
   category: Climate Response
   name: AI and Climate Change
   playlist:  https://www.youtube.com/playlist?list=PLnpWOQFK76gqeFuNocGeynrhuCZ4Rbf69
-  tutorials: 6
+  tutorials: 7


### PR DESCRIPTION
Changes the number of tutorials for w2d4 from 6 to 7 to include the new bonus tutorial W2D4T7.