### PR TITLE
Fix nbformat: removed invalid metadata for CI and HTML render

### DIFF
--- a/tutorials/W2D4_AIandClimateChange/W2D4_Tutorial7.ipynb
+++ b/tutorials/W2D4_AIandClimateChange/W2D4_Tutorial7.ipynb
@@ -2,12 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "8eeed120",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Bonus Tutorial 7: Deep Learning for Climate Prediction with CNN-LSTMs (PyTorch)\n",
     "\n",
@@ -21,18 +17,13 @@
     "\n",
     "**Production editors:**  Jenna Pearson, Konstantine Tsafatinos\n",
     "\n",
-    "**Our 2024 Sponsors:** CMIP, NFDI4Earth\n",
-    "\n"
+    "**Our 2024 Sponsors:** CMIP, NFDI4Earth"
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "GMS6-O5IRpKM",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Tutorial Objectives\n",
     "\n",
@@ -53,23 +44,17 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "YCfpwKbfZCw2",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
-    "#Setup"
+    "# Setup"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "zjKrQlOevIYd",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install cartopy xarray --quiet"
@@ -79,9 +64,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cvf3Ux3GZCw2",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np # Numerical computing\n",
@@ -116,10 +99,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "YPGgRQH-Q7r8",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Install and import feedback gadget\n",
@@ -146,10 +126,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "uLkA23KzRZ_L",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Figure settings\n",
@@ -165,10 +142,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "jGzF_XKCbrDJ",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell for Data retrieval\n",
@@ -244,10 +218,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "AZobH8uCZCw3",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Helper functions  {\"run\":\"auto\",\"display-mode\":\"form\"}\n",
@@ -541,10 +512,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "qK_rGiNeZCw3",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Set random seed, when using `pytorch` {\"run\":\"auto\",\"display-mode\":\"form\"}\n",
@@ -587,10 +555,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "jKbb6F5eZCw3",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Set device (GPU or CPU). Execute `set_device()`\n",
@@ -615,12 +580,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Pt0DOB8Ut_iA",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "> **Note:**  \n",
     "> GPU acceleration is optional for this tutorial. All code can be executed on CPUs, though some steps (especially model training) may take longer. Please allow additional time when running on CPU-only environments and meanwhile go through the remaining tutorial.\n"
@@ -630,10 +591,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "G9bZ6Qt-bbS7",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Video 1: Deep Learning Techniques\n",
@@ -688,9 +646,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8o047eEWb2cx",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\n",
@@ -702,10 +658,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "wcyhkzUqcA5c",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @markdown\n",
@@ -722,10 +675,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8dOmCfLncA-A",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -734,12 +684,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "vH8FnuriZCw3",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 1. Transitioning to Deep Learning with PyTorch: From Machine Learning to Deep Learning in Climate Data Analysis\n",
     "\n",
@@ -871,10 +817,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "_AVUh9EAcPsd",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -883,12 +826,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "q5t-SckmZCw4",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 2: ClimateBench Data Reloaded - Now in PyTorch!\n",
     "\n",
@@ -901,12 +840,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "-ocmORr7ZCw4",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "<details>\n",
@@ -958,12 +893,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "fPCT3GrTZCw4",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 2.1 The Shift to Spatiotemporal Data: ClimateBench in Native Format  \n",
     "\n",
@@ -1024,24 +955,16 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Kzi33dVNZCw4",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "First, Define the path to the training data and then define the climate scenarios"
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "aGdvbwT-TtKE",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Section 2.1.1 Set Data path\n",
     "\n"
@@ -1051,9 +974,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ei1lZhMTUpcK",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data_path = \"Data/train_val/\" #Path to the data whihc is temporarily loaded to colab RAM"
@@ -1063,9 +984,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "icrnaDP1ZCw5",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#define the climate scenarios of interest\n",
@@ -1075,12 +994,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "_WRHRwUlZCw5",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 2.2 Loading & Processing The Full Raw ClimateBench Data  \n",
     "\n",
@@ -1109,10 +1024,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ZAfP6CooZCw5",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @markdown Make sure you execute this cell to load the data in two variables `X_train` and `Y_train`\n",
@@ -1175,12 +1087,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "L1QhMDJ4ZCw5",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "<details>\n",
@@ -1214,12 +1122,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "j5xNpiQbZCw5",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "So we have just loaded the datatset in two variables `X_train` and `Y_train`\n",
     "\n",
@@ -1230,9 +1134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4KBKWDFaZCw5",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(X_train)"
@@ -1242,9 +1144,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "NHQO55-yZCw5",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(Y_train)"
@@ -1252,12 +1152,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "lvIvQxSsZCw6",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 2.3 Visualization of the Data\n",
     "\n",
@@ -1270,10 +1166,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "m9Q6dWsLlL_X",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell to activate Interactive Climate Data Heatmap {\"run\":\"auto\",\"vertical-output\":true,\"display-mode\":\"form\"}\n",
@@ -1314,12 +1207,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "cxs-TyzbZCw6",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "2️⃣ **Interactive Time Series for a Specific Location**  \n",
     "Allow users to select a location (lat, lon) and see how a climate variable changes over time."
@@ -1329,10 +1218,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ep22U2vOZCw6",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell to activate widget\n",
@@ -1341,12 +1227,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ZqAx3683ZCw6",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "3️⃣ ***Widget for Selecting Different Climate Variables***  \n",
     "Use the dropdown widget to let yourself explore different variables dynamically."
@@ -1356,10 +1238,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "x1tCNfhWZCw6",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell to activate Interactive widget {\"run\":\"auto\",\"vertical-output\":true,\"display-mode\":\"form\"}\n",
@@ -1384,10 +1263,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0IwPUX6Gccj8",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -1396,12 +1272,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Js7OcYAAZCw6",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 3: Data Normalization\n",
     "\n",
@@ -1465,9 +1337,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ynGn2aodZCw7",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# **3. Data Normalization**\n",
@@ -1510,9 +1380,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4aAE4_Z5ZCw7",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# **Step 1: Compute mean and standard deviation for each variable across the dataset**\n",
@@ -1546,10 +1414,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "vI5C6mu0c80c",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -1558,12 +1423,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "UzZ6HlgFZCw7",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 4: Reshaping Data for the CNN-LSTM Model\n",
     "\n",
@@ -1573,12 +1434,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ldlD7S70Uesi",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 4.1 The Sliding Window Approach\n",
@@ -1615,12 +1472,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "G20dOxtwUgTG",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 4.2 Implementing the Sliding Window Transformation\n",
@@ -1636,9 +1489,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "k1Ay81S7UnSS",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# **4. Reshape Data to Feed into the Model**\n",
@@ -1649,9 +1500,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "v5zBq6vvZCw8",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Function to reshape input data for training\n",
@@ -1727,12 +1576,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "HsEuYfGmZCw8",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "---\n",
     "<details>\n",
@@ -1765,10 +1610,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "DwqH78qVc_3-",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -1777,12 +1619,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "B7uMkGyQZCw8",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 5: Preparing the Training Data\n",
     "<details>\n",
@@ -1820,9 +1658,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "mG_iZYI_ZCw8",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Section 5: Preparing Training Data for CNN-LSTM Model\n",
@@ -1866,12 +1702,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "30-Kg26vZCw8",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "The above code prepares climate data for training a CNN-LSTM model by structuring it into PyTorch tensors. First, it concatenates climate data from multiple emission scenarios to ensure a unified dataset. Next, it converts NumPy arrays to PyTorch tensors, enabling GPU acceleration. Finally, it rearranges tensor dimensions using .permute() to match the model’s expected format: (batch_size, timesteps, channels, height, width). These steps ensure the data is properly formatted for deep learning, preventing shape mismatches during training."
    ]
@@ -1880,9 +1712,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "tcw0do7CZCw8",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "X_train_torch[0][0][0][0][0]"
@@ -1890,12 +1720,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "IuHd4HzwZCw9",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details><summary> <font color='lightGreen'>Recap: Understnding ClimateBench Dataset Shape for Deep Learning  </font></summary>\n",
     "\n",
@@ -1929,12 +1755,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "seypdDgaZCw9",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 5.1: Interactive Climate Data Explorer  \n",
     "\n",
@@ -1945,10 +1767,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "RPtDS1JRZCw9",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @markdown Make sure you execute this cell to enable the widget!\n",
@@ -1961,12 +1780,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ZAjfZy_7d5NU",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "\n",
@@ -1977,12 +1792,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "MPzl9SVGZCw9",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 5.2: Spatiotemporal Climate Data Explorer  \n",
     "\n",
@@ -1999,10 +1810,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "KzL1vMMnZCw9",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @markdown Make sure you execute this cell to enable the widget!<br>\n",
@@ -2012,12 +1820,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "G9EDNtCQnzq6",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Interpreting the Animation\n",
     "\n",
@@ -2033,10 +1837,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "CnBIyM7JdD6I",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -2045,12 +1846,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "9k6hl90KZCw9",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 6: Defining the CNN-LSTM Model Architecture\n",
     "\n",
@@ -2066,12 +1863,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "nnTh9BxDVBKa",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 6.1 Understanding the CNN-LSTM Hybrid Model\n",
@@ -2112,12 +1905,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "7iWzhwItVFZh",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 6.2 Implementing the CNN-LSTM Model in PyTorch\n",
@@ -2170,9 +1959,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7zjZmmlYZCw-",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TimeDistributed(nn.Module):\n",
@@ -2218,12 +2005,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "zVlrg4TQZCw-",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details>\n",
     "<summary> <font color='lightGreen'> Breaking Down the Code </font></summary>\n",
@@ -2254,12 +2037,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "EhZNTrFzZCw-",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Section 6.2.1. Building the CNN-LSTM Model  \n",
     "Now, we define the full **CNN-LSTM model**, integrating:  \n",
@@ -2303,9 +2082,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "WqCjGjE7ZCw-",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# --- Define helper modules ---\n",
@@ -2376,17 +2153,13 @@
     "        Returns:\n",
     "        tensor: Reshaped tensor with dimensions (batch, 1, height, width).\n",
     "        \"\"\"\n",
-    "        return x.view(-1, *self.shape)  # Reshape while preserving batch size"
+    "        return x.view(-1, *self.shape)  # Reshape while preserving batch size\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "41dd5b1d-7495-43a5-997b-d5c1e687715f",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Coding Exercise 6.2.2: Implementing the forward pass of CNN_LSTM model, which is designed for spatiotemporal climate forecasting.\n",
     "\n",
@@ -2417,9 +2190,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0703bd6c-2644-4c86-9118-f8c0e49a1c93",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# --- Define the CNN-LSTM Model ---\n",
@@ -2507,9 +2278,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "139cd239-a9a3-488e-aeb5-ac4235d4b2c7",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -2586,9 +2355,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1fZbuAligWbz",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# test your solution\n",
@@ -2604,12 +2371,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "3tEz106tZCw_",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details>\n",
     "<summary> <font color='lightGreen'> Breaking Down the Code </font></summary>\n",
@@ -2639,12 +2402,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "WSZ6uuPyZCw_",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Section 6.2.4 Final Step: Instantiating and Checking Model\n",
     "Before training, let’s instantiate our model and check its structure."
@@ -2654,9 +2413,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1YnZq0MLZCw_",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate Model\n",
@@ -2668,12 +2425,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "cJsyfmmWZCw_",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "🔎 What do you observe in the architecture?\n",
@@ -2685,10 +2438,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "P7xnz7NodH-5",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -2697,12 +2447,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "1jbub84UZCxA",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "---\n",
     "# Section 7: Defining the Model, Loss Function, and Optimizer\n",
@@ -2779,9 +2525,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "qfJs9xiFZCxA",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 7. Define Model, Loss Function, and Optimizer\n",
@@ -2803,12 +2547,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ZZdvCD7jZCxA",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "We saw the **CNN-LSTM model** architecture, where a **TimeDistributed CNN** extracts spatial patterns, an **LSTM** captures temporal dependencies, and a **fully connected layer** reconstructs spatial grids.  \n",
     "\n",
@@ -2822,10 +2562,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "p0KAYgNKdMNG",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -2834,12 +2571,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "JkC0W7jSZCxA",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 8: Training Loop with Validation and Early Stopping\n",
     "\n",
@@ -2852,12 +2585,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "zMqK6kedW0jZ",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 8.1 Understanding the Training Process  \n",
     "\n",
@@ -2875,12 +2604,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Fu5TRT3qW2h9",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 8.2 Key Hyperparameters in Training  \n",
@@ -2895,12 +2620,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "akdkIMv4W36b",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "\n",
     "## Section 8.3 Preparing for Training  \n",
@@ -2913,9 +2634,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "MlG17kw-ZCxB",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Early stopping parameters\n",
@@ -2937,12 +2656,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "2eiPm1YWZCxB",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 8.4 Training Loop with Early Stopping  \n",
     "\n",
@@ -2966,12 +2681,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "333c3f99-0ade-4ac0-838c-4fc9e7dfa0a5",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "### Coding Exercise 8.4: Training a CNN with weight and gradient tracking\n",
     "\n",
@@ -2993,9 +2704,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fbc55979-3119-4b8f-b863-967b936ef8ea",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def train_model(cnn_model, train_loader, val_loader, optimizer, criterion, num_epochs, patience):\n",
@@ -3086,9 +2795,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ltFvRM1OvsAh",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -3170,9 +2877,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "xUGAoqpHg2VH",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "## Uncomment below to test your implementation\n",
@@ -3183,12 +2888,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "LPPMEg6OsSdx",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "> ⚠️ **Note:** Training will take some time depending on the number of epochs.  \n",
     "> 💡 Run the traning and in the meantime, you can explore the remaining sections of the tutorial.\n"
@@ -3198,9 +2899,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7e41b465-d058-4154-860a-f4a182c71171",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#call the training function\n",
@@ -3212,24 +2911,16 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "7ef6ba8f-f067-4c0c-bfc6-d6bbf3d3d4da",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "> Note: Please run the remaining cell and then change the number of epochs to at least 30 in the above cell to get better results and improved visualization in the upcoming section."
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "lH9azKKqZCxC",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details>\n",
     "<summary> <font color='lightGreen'>Explanation:</font></summary>\n",
@@ -3255,10 +2946,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "OwGRT4PbZCxC",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell to activate Interactive widget {\"run\":\"auto\",\"vertical-output\":true,\"display-mode\":\"form\"}\n",
@@ -3271,10 +2959,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "zSY83MJrZCxC",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this cell to activate Interactive widget {\"run\":\"auto\",\"display-mode\":\"form\"}\n",
@@ -3286,10 +2971,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "pj_qZ10ZdPgG",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -3298,12 +2980,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "__d0OI3eZCxC",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 9: Making Predictions and Visualizing Results\n",
     "\n",
@@ -3312,12 +2990,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "J2-iUaqQXp7r",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 9.1 Making Predictions\n",
     "\n",
@@ -3328,9 +3002,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "jzPYW1SqZCxC",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Example of prediction (using the training data for demonstration)\n",
@@ -3343,12 +3015,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Xt1C7_zYZCxC",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details>\n",
     "<summary> <font color='lightGreen'>Explanation: </font></summary>\n",
@@ -3363,12 +3031,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "3dOVCtcAZCxD",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 9.2 Visualizing Results\n",
     "Visualizing the model's predictions is crucial for understanding its performance and identifying potential issues. We can use libraries like `matplotlib` and `cartopy` to plot the predicted temperature and compare it to the actual temperature."
@@ -3378,9 +3042,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "Id1nIGBuZCxD",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Visualization example (plotting the first prediction)\n",
@@ -3394,12 +3056,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "NxWW3WahZCxD",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "<details>\n",
     "<summary> <font color='lightGreen'>Explanation </font></summary>\n",
@@ -3417,12 +3075,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "CBQBPpu-ZCxD",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "**0. Using Cartopy for Geographic Projections**:\n",
     "\n",
@@ -3433,9 +3087,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bhHcT5QFZCxD",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -3458,12 +3110,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "6RZGbsP9ZCxD",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "**1 Difference (Error) Map**  \n",
     "To see where the model deviates from the actual temperature."
@@ -3473,9 +3121,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "K-3YMDdaZCxD",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -3498,12 +3144,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "WI7RWj1EZCxD",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "🔥 Insight: This highlights over- and under-predictions across the globe.\n",
     "\n",
@@ -3515,9 +3157,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "Tm2KbF49ZCxE",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -3547,12 +3187,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "Pq7x8IEiZCxE",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "📈 Insight: Does the model capture temperature variations across latitudes accurately?\n",
     "\n",
@@ -3564,9 +3200,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "j99B6-iCZCxE",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.figure(figsize=(7, 5))\n",
@@ -3585,12 +3219,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "UUKwJO2iZCxE",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "📊 Insight: If errors are centered around 0, the model has no systematic bias."
    ]
@@ -3599,9 +3229,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e2z4Z0w3ZCxE",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 5. Prediction vs. Ground Truth Visualization\n",
@@ -3616,12 +3244,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "26b4caca-3cd8-4b31-b3f9-aa54d220e48d",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "> Note: For better visualization, please go to the training part and set the number of epochs to at least 30. \n",
     "> This will help ensure that your model has sufficiently learned from the data, allowing for a more meaningful comparison between the predictions and the actual ground truth during visualization."
@@ -3629,12 +3253,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "OMzUGLSa9vAg",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Questions 9.2: How can we \"trust\" an emulator’s prediction?"
    ]
@@ -3643,9 +3263,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "nZIzYhjH-BWA",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
@@ -3660,10 +3278,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "trqV-hfUdU9i",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -3672,12 +3287,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "P0OmF0cPZCxE",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 10 : Make final prediction on the Test Data from ClimateBench Repository\n",
     "\n"
@@ -3687,9 +3298,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "KRQWyjuwp6lO",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Define the path to the test data\n",
@@ -3698,12 +3307,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "8kGBJr9sX5rc",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 10.1 Make prediction for precipitation-related variables"
    ]
@@ -3712,9 +3317,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "gK0FSEDDZCxE",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# ==============================================\n",
@@ -3790,10 +3393,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1DJkW6UpZCxF",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Run this Cell to See the Plot of the Results {\"run\":\"auto\",\"display-mode\":\"form\"}\n",
@@ -3814,24 +3414,16 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ZamTfMTdZCxF",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "## Section 10.2 Run Training and Predictions for Each Target Variable from the `test set` of the Climatebench dataset"
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "196680a2-5861-43d8-ab95-eac800fb3369",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "> **Note:**  \n",
     "> The code for training and predictions on multiple target variables is provided below but has been commented out by default to avoid runtime issues on automated execution environments (e.g., CI pipelines, limited Colab runtimes).  \n",
@@ -3845,9 +3437,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "BnN97_ZjZCxF",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# #Run Training and Predictions for Each Target Variable from the test set of the Climatebench dataset\n",
@@ -3954,10 +3544,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "15c74158-0162-4cb4-953a-0051b769bc54",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -3966,12 +3553,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "7an3PyJzZCxH",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Section 11: Conclusion\n",
     "\n",
@@ -3992,10 +3575,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cM_lFqHtdeC8",
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
@@ -4004,12 +3584,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "ogNPBoRReXQK",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Summary\n",
     "\n",
@@ -4029,12 +3605,8 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "id": "4D50phKCeQT_",
-   "metadata": {
-    "execution": {}
-   },
-   "outputs": [],
+   "metadata": {},
    "source": [
     "# Resources\n",
     "1. [Neuromatch Deep Learning Course](https://deeplearning.neuromatch.io/tutorials/W1D1_BasicsAndPytorch/student/W1D1_Tutorial1.html)\n",
@@ -4045,17 +3617,6 @@
   }
  ],
  "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "include_colab_link": true,
-   "name": "W2D4_Tutorial7",
-   "toc_visible": true
-  },
-  "kernel": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -4071,7 +3632,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Removed invalid metadata fields (`execution_count`, `outputs`) from markdown cells
- Notebook now passes `nbconvert` validation and renders properly in HTML
- Confirmed locally with `jupyter nbconvert`
- No outputs included; CI-safe version
